### PR TITLE
potential fix for issue #19 - Fix navBar navigation Buttons

### DIFF
--- a/public/css/main_out.css
+++ b/public/css/main_out.css
@@ -856,8 +856,8 @@ html {
   border-radius: var(--rounded-btn, 0.5rem);
   border-color: transparent;
   border-color: oklch(var(--btn-color, var(--b2)) / var(--tw-border-opacity));
-  padding-left: 1rem;
-  padding-right: 1rem;
+  padding-left: 0.8rem;
+  padding-right: 0.8rem;
   text-align: center;
   font-size: 0.875rem;
   line-height: 1em;

--- a/public/css/main_out.css
+++ b/public/css/main_out.css
@@ -856,8 +856,8 @@ html {
   border-radius: var(--rounded-btn, 0.5rem);
   border-color: transparent;
   border-color: oklch(var(--btn-color, var(--b2)) / var(--tw-border-opacity));
-  padding-left: 0.8rem;
-  padding-right: 0.8rem;
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
   text-align: center;
   font-size: 0.875rem;
   line-height: 1em;


### PR DESCRIPTION
A minor change to lines 859 and 860 in the main_out.css file on the btn class padding-left and padding-right reduced to 0.75rem to stop overlap with search bar.
